### PR TITLE
Enforce Samsara token requirement

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,22 +5,29 @@ import os
 load_dotenv()
 
 # Samsara API Configuration
-API_TOKEN        = os.getenv("SAMSARA_BEARER_TOKEN")
+API_TOKEN = os.getenv("SAMSARA_BEARER_TOKEN")
+if API_TOKEN is None:
+    raise EnvironmentError("SAMSARA_BEARER_TOKEN must be set")
 
 # Directory Configuration
-PAYCOM_DIR       = Path(os.getenv("PAYCOM_DIR", "data"))
-LOG_FILE         = Path(os.getenv("LOG_FILE", "driver_sync.log"))
+PAYCOM_DIR = Path(os.getenv("PAYCOM_DIR", "data"))
+LOG_FILE = Path(os.getenv("LOG_FILE", "driver_sync.log"))
 
 # OneDrive Report Directories
-HIRES_DIR        = Path(os.getenv("HIRES_DIR", r"C:\Users\Jonathan\OneDrive - JECOfsb\Flow\Hires"))
-TERMS_DIR        = Path(os.getenv("TERMS_DIR", r"C:\Users\Jonathan\OneDrive - JECOfsb\Flow\Terms"))
+HIRES_DIR = Path(
+    os.getenv("HIRES_DIR", r"C:\Users\Jonathan\OneDrive - JECOfsb\Flow\Hires")
+)
+TERMS_DIR = Path(
+    os.getenv("TERMS_DIR", r"C:\Users\Jonathan\OneDrive - JECOfsb\Flow\Terms")
+)
 
 # Request Configuration
-REQUEST_TIMEOUT  = 10
-BATCH_SIZE       = 40           # 40 × 1.5 s sleeps stays under 100 req/min
+REQUEST_TIMEOUT = 10
+BATCH_SIZE = 40  # 40 × 1.5 s sleeps stays under 100 req/min
 
 # Driver Defaults
 DEFAULT_PASSWORD = os.getenv("DEFAULT_DRIVER_PASSWORD", "JecoPass123!")
+
 
 # Create a settings object for easy access
 class Settings:
@@ -32,5 +39,6 @@ class Settings:
     request_timeout = REQUEST_TIMEOUT
     batch_size = BATCH_SIZE
     default_password = DEFAULT_PASSWORD
+
 
 settings = Settings()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_config_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SAMSARA_BEARER_TOKEN", raising=False)
+    if "config" in sys.modules:
+        del sys.modules["config"]
+    with pytest.raises(EnvironmentError):
+        import config  # noqa: F401
+
+
+def test_config_loads_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SAMSARA_BEARER_TOKEN", "token123")
+    if "config" in sys.modules:
+        del sys.modules["config"]
+    import config
+
+    assert config.settings.api_token == "token123"

--- a/tests/test_samsara_client.py
+++ b/tests/test_samsara_client.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_client_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SAMSARA_BEARER_TOKEN", raising=False)
+    if "src.samsara_client" in sys.modules:
+        del sys.modules["src.samsara_client"]
+    with pytest.raises(EnvironmentError):
+        import src.samsara_client  # noqa: F401
+
+
+def test_client_sets_authorization_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    token = "abc123"
+    monkeypatch.setenv("SAMSARA_BEARER_TOKEN", token)
+    if "src.samsara_client" in sys.modules:
+        del sys.modules["src.samsara_client"]
+    import src.samsara_client as sc
+
+    assert sc.SESSION.headers["Authorization"] == f"Bearer {token}"

--- a/usage_guide.md
+++ b/usage_guide.md
@@ -12,6 +12,9 @@ This system automatically processes new hires and terminations from OneDrive Exc
 
 ## Quick Start
 
+Before running any commands, set the `SAMSARA_BEARER_TOKEN` environment variable.
+The utilities will raise an `EnvironmentError` if it is missing.
+
 ### 1. Process Everything (Recommended)
 ```bash
 # Process both terminations and new hires using latest files


### PR DESCRIPTION
## Summary
- ensure config errors if `SAMSARA_BEARER_TOKEN` is missing
- validate token before configuring samsara client headers
- note the required environment variable in the usage guide and add tests

## Testing
- `ruff check .` *(fails: E722 Do not use bare `except`, F541 f-string without any placeholders, F401 imported but unused, and more)*
- `pre-commit run --all-files` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68938ae6e4d88328ba449c9f59a8ba6d