### PR TITLE
Fix driver payload tag typing

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from typing import Optional, List
+
 
 class CarrierSettings(BaseModel):
     carrierName: str
@@ -7,6 +8,7 @@ class CarrierSettings(BaseModel):
     homeTerminalAddress: str
     homeTerminalName: str
     mainOfficeAddress: str
+
 
 class DriverAddPayload(BaseModel):
     carrierSettings: CarrierSettings
@@ -21,6 +23,6 @@ class DriverAddPayload(BaseModel):
     eldExemptReason: str = "Short Haul"
     locale: str = "us"
     timezone: str = "America/Chicago"
-    tagIds: [List[str]]
-    peerGroupTagId: [str]
+    tagIds: List[str]
+    peerGroupTagId: Optional[str] = None
     usDriverRulesetOverride: dict | None = None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_driver_add_payload_typing() -> None:
+    from src import models
+
+    payload = models.DriverAddPayload(
+        carrierSettings=models.CarrierSettings(
+            carrierName="Acme Logistics",
+            dotNumber=1234567,
+            homeTerminalAddress="123 Main St",
+            homeTerminalName="Main",
+            mainOfficeAddress="456 Elm St",
+        ),
+        externalIds={"employeeId": "E123"},
+        name="John Doe",
+        username="jdoe",
+        password="secret",
+        notes="Test driver",
+        phone="555-5555",
+        licenseState="CA",
+        tagIds=["tag1", "tag2"],
+        peerGroupTagId="group1",
+    )
+
+    assert payload.tagIds == ["tag1", "tag2"]
+    assert payload.peerGroupTagId == "group1"
+
+    payload_no_peer = models.DriverAddPayload(
+        carrierSettings=payload.carrierSettings,
+        externalIds=payload.externalIds,
+        name=payload.name,
+        username=payload.username,
+        password=payload.password,
+        notes=payload.notes,
+        phone=payload.phone,
+        licenseState=payload.licenseState,
+        tagIds=payload.tagIds,
+    )
+
+    assert payload_no_peer.peerGroupTagId is None


### PR DESCRIPTION
## Summary
- fix DriverAddPayload tagIds and peerGroupTagId type hints
- add unit test covering DriverAddPayload construction

## Testing
- `pre-commit run --all-files` *(fails: .pre-commit-config.yaml is not a file)*
- `ruff check src/models.py tests/test_models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68938f2c88048328b28bc6927e1ef302