### PR TITLE
refactor: split imports in samsara client

### DIFF
--- a/src/samsara_client.py
+++ b/src/samsara_client.py
@@ -4,8 +4,12 @@ Enhanced with external ID support for reliable driver matching.
 """
 
 from __future__ import annotations
-import os, logging, backoff, requests
-from typing import Iterator, Any, Dict, List, Optional, Literal
+
+import backoff
+import logging
+import os
+import requests
+from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel
 from urllib.parse import quote
 


### PR DESCRIPTION
## Summary
- split combined imports in `samsara_client` into individual import statements
- remove unused `Iterator` from typing imports

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893967742288328b86e7e38764cca7d