### PR TITLE
Add read-only username availability check

### DIFF
--- a/tests/test_username_manager.py
+++ b/tests/test_username_manager.py
@@ -49,3 +49,20 @@ def test_persistence(tmp_path: Path) -> None:
 
     new_manager = UsernameManager(csv_path=csv)
     assert new_manager.exists(username)
+
+
+def test_check_available_does_not_modify_state(tmp_path: Path) -> None:
+    csv = tmp_path / "usernames.csv"
+    manager = UsernameManager(csv_path=csv)
+
+    manager.add_username("alice")
+    manager.flush()
+
+    before = csv.read_text()
+
+    predicted = manager.check_available("alice")
+    assert predicted == "alice2"
+    assert not manager.exists(predicted)
+
+    after = csv.read_text()
+    assert before == after


### PR DESCRIPTION
## Summary
- add `check_available` method to `UsernameManager` to preview next available username without persisting
- document usage of new method
- test prediction behavior and ensure no CSV modification

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893a1c4b7248328b07d96372e74b8b1