### PR TITLE
chore: use model_dump for logging

### DIFF
--- a/src/add_drivers.py
+++ b/src/add_drivers.py
@@ -266,7 +266,7 @@ def main(
                 log.info(f"          External ID: paycomname:{paycom_key}")
                 if verbose:
                     log.debug(
-                        f"Payload: {json.dumps(payload.dict(exclude_none=True), indent=2)}"
+                        f"Payload: {json.dumps(payload.model_dump(exclude_none=True), indent=2)}"
                     )
                 stats["added"] += 1
             else:


### PR DESCRIPTION
## Summary
- use `model_dump` for driver payload logging

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b888c7a48328850f694b7ff95fa6