### PR TITLE
Handle OS errors during UsernameManager cleanup

### DIFF
--- a/src/username_manager.py
+++ b/src/username_manager.py
@@ -100,8 +100,8 @@ class UsernameManager:
         """Flush pending usernames when the manager is garbage collected."""
         try:
             self.flush()
-        except Exception:  # pragma: no cover - best effort
-            pass
+        except OSError:  # pragma: no cover - best effort
+            log.exception("Error flushing usernames on cleanup")
 
     def make_unique(self, base_username: str) -> str:
         """


### PR DESCRIPTION
## Summary
- Narrow exception handling in `UsernameManager.__del__` to catch and log `OSError`

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b8882df08328975993753d868dc2