### PR TITLE
Handle optional driver phone numbers

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -17,7 +17,7 @@ class DriverAddPayload(BaseModel):
     username: str
     password: str
     notes: str
-    phone: Optional[str]
+    phone: str | None = None
     licenseState: str
     eldExempt: bool = True
     eldExemptReason: str = "Short Haul"

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -118,6 +118,7 @@ def row_to_payload(row) -> DriverAddPayload | None:
         username=username,
         password=settings.default_password,
         notes=f"Hire Date: {row.Hire_Date:%m-%d-%Y}",
+        phone=getattr(row, "Phone", None),
         licenseState=row.State,
         peerGroupTagId=pos_tag,
         tagIds=tag_ids,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -44,3 +44,26 @@ def test_driver_add_payload_typing() -> None:
     )
 
     assert payload_no_peer.peerGroupTagId is None
+
+
+def test_driver_add_payload_defaults_phone_none() -> None:
+    from src import models
+
+    payload = models.DriverAddPayload(
+        carrierSettings=models.CarrierSettings(
+            carrierName="Acme Logistics",
+            dotNumber=1234567,
+            homeTerminalAddress="123 Main St",
+            homeTerminalName="Main",
+            mainOfficeAddress="456 Elm St",
+        ),
+        externalIds={"employeeId": "E123"},
+        name="Jane Doe",
+        username="jdoe2",
+        password="secret",
+        notes="Test driver",
+        licenseState="CA",
+        tagIds=["tag1"],
+    )
+
+    assert payload.phone is None

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,0 +1,86 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from datetime import datetime
+import importlib
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+class DummyUM:
+    def make_unique(self, base: str) -> str:
+        return base
+
+
+def _setup_transformer(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SAMSARA_BEARER_TOKEN", "token")
+
+    import mapping_loader as ml
+    import username_manager as um
+    import pandas as pd
+    import pandas.api.types as pd_types
+
+    if not hasattr(pd_types, "isna"):
+        monkeypatch.setattr(pd_types, "isna", pd.isna, raising=False)
+
+    monkeypatch.setattr(ml, "load_position_tags", lambda: {})
+    monkeypatch.setattr(
+        ml,
+        "load_location_tags_and_timezones",
+        lambda: {"LocA": {"tag_id": "tagloc", "timezone": "tz"}},
+    )
+    monkeypatch.setattr(ml, "load_never_positions", lambda: set())
+    monkeypatch.setattr(um, "get_username_manager", lambda: DummyUM())
+
+    import src.transformer as transformer
+    importlib.reload(transformer)
+
+    monkeypatch.setattr(
+        transformer,
+        "_carrier_settings",
+        lambda: transformer.CarrierSettings(
+            carrierName="Acme",
+            dotNumber=123,
+            homeTerminalAddress="123 Main",
+            homeTerminalName="Main",
+            mainOfficeAddress="456 Elm",
+        ),
+    )
+
+    return transformer
+
+
+def test_row_to_payload_missing_phone(monkeypatch: pytest.MonkeyPatch) -> None:
+    transformer = _setup_transformer(monkeypatch)
+    row = SimpleNamespace(
+        Position=None,
+        Work_Location="LocA",
+        Legal_Firstname="Jane",
+        Legal_Lastname="Doe",
+        Hire_Date=datetime(2024, 1, 1),
+        State="CA",
+    )
+    payload = transformer.row_to_payload(row)
+    assert payload.phone is None
+
+
+def test_row_to_payload_with_phone(monkeypatch: pytest.MonkeyPatch) -> None:
+    transformer = _setup_transformer(monkeypatch)
+    row = SimpleNamespace(
+        Position=None,
+        Work_Location="LocA",
+        Legal_Firstname="John",
+        Legal_Lastname="Smith",
+        Hire_Date=datetime(2024, 1, 1),
+        State="CA",
+        Phone="555-1234",
+    )
+    payload = transformer.row_to_payload(row)
+    assert payload.phone == "555-1234"


### PR DESCRIPTION
## Summary
- default `DriverAddPayload.phone` to `None`
- pass optional phone field from rows when building payloads
- add tests for phone handling in models and transformer

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b8a5833c8328a4a2f57ab7fda976