### PR TITLE
refactor: use pandas namespace for NaN check

### DIFF
--- a/src/transformer.py
+++ b/src/transformer.py
@@ -3,7 +3,7 @@ from config import settings
 from username_manager import get_username_manager
 import re
 import logging
-from pandas.api.types import isna
+import pandas as pd
 from mapping_loader import (
     load_position_tags,
     load_location_tags_and_timezones,
@@ -76,7 +76,7 @@ def row_to_payload(row) -> DriverAddPayload | None:
     tz = loc_info["timezone"] or "America/Chicago"
 
     pos_tag = None
-    if row.Position and not isna(row.Position) and row.Position.strip():
+    if row.Position and not pd.isna(row.Position) and row.Position.strip():
         pos_tag = _POS_TAGS.get(row.Position.strip())
         if not pos_tag:
             _log.warning(

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -40,6 +40,7 @@ def _setup_transformer(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(um, "get_username_manager", lambda: DummyUM())
 
     import src.transformer as transformer
+
     importlib.reload(transformer)
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- replace deprecated pandas API isna import with `import pandas as pd`
- check driver position using `pd.isna`
- run pre-commit hooks (formatting)

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893baf0975883288a0c3691a4f27e19