### PR TITLE
Remove CarrierSettings from driver payload

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -2,16 +2,7 @@ from pydantic import BaseModel
 from typing import Optional, List
 
 
-class CarrierSettings(BaseModel):
-    carrierName: str
-    dotNumber: int
-    homeTerminalAddress: str
-    homeTerminalName: str
-    mainOfficeAddress: str
-
-
 class DriverAddPayload(BaseModel):
-    carrierSettings: CarrierSettings
     externalIds: dict[str, str]
     name: str
     username: str

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -1,4 +1,4 @@
-from src.models import DriverAddPayload, CarrierSettings
+from src.models import DriverAddPayload
 from config import settings
 from username_manager import get_username_manager
 import re
@@ -109,7 +109,6 @@ def row_to_payload(row) -> DriverAddPayload | None:
     )
 
     return DriverAddPayload(
-        carrierSettings=_carrier_settings(),
         externalIds={
             "paycomname": paycom_key,  # Add the composite key
             "email": f"{username}@example.com",
@@ -126,16 +125,4 @@ def row_to_payload(row) -> DriverAddPayload | None:
         timezone=tz,
         eldExempt=True,
         eldExemptReason="Short Haul",
-    )
-
-
-def _carrier_settings() -> CarrierSettings:
-    """Create carrier settings (implementation depends on your config)."""
-    # This would come from your settings/config
-    return CarrierSettings(
-        carrierName=settings.carrier_name,
-        dotNumber=settings.dot_number,
-        homeTerminalAddress=settings.home_terminal_address,
-        homeTerminalName=settings.home_terminal_name,
-        mainOfficeAddress=settings.main_office_address,
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,13 +10,6 @@ def test_driver_add_payload_typing() -> None:
     from src import models
 
     payload = models.DriverAddPayload(
-        carrierSettings=models.CarrierSettings(
-            carrierName="Acme Logistics",
-            dotNumber=1234567,
-            homeTerminalAddress="123 Main St",
-            homeTerminalName="Main",
-            mainOfficeAddress="456 Elm St",
-        ),
         externalIds={"employeeId": "E123"},
         name="John Doe",
         username="jdoe",
@@ -32,7 +25,6 @@ def test_driver_add_payload_typing() -> None:
     assert payload.peerGroupTagId == "group1"
 
     payload_no_peer = models.DriverAddPayload(
-        carrierSettings=payload.carrierSettings,
         externalIds=payload.externalIds,
         name=payload.name,
         username=payload.username,
@@ -50,13 +42,6 @@ def test_driver_add_payload_defaults_phone_none() -> None:
     from src import models
 
     payload = models.DriverAddPayload(
-        carrierSettings=models.CarrierSettings(
-            carrierName="Acme Logistics",
-            dotNumber=1234567,
-            homeTerminalAddress="123 Main St",
-            homeTerminalName="Main",
-            mainOfficeAddress="456 Elm St",
-        ),
         externalIds={"employeeId": "E123"},
         name="Jane Doe",
         username="jdoe2",

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -43,18 +43,6 @@ def _setup_transformer(monkeypatch: pytest.MonkeyPatch):
 
     importlib.reload(transformer)
 
-    monkeypatch.setattr(
-        transformer,
-        "_carrier_settings",
-        lambda: transformer.CarrierSettings(
-            carrierName="Acme",
-            dotNumber=123,
-            homeTerminalAddress="123 Main",
-            homeTerminalName="Main",
-            mainOfficeAddress="456 Elm",
-        ),
-    )
-
     return transformer
 
 


### PR DESCRIPTION
## Summary
- remove unused CarrierSettings model and related transformer helper
- simplify DriverAddPayload to exclude carrier information
- update tests accordingly

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893bd78f27c8328bcd3f6c26a06fa64