### PR TITLE
Make file finder lookup static

### DIFF
--- a/src/file_finder.py
+++ b/src/file_finder.py
@@ -59,8 +59,9 @@ class PayrollFileFinder:
         """
         return self._find_latest_file(self.terms_dir, self.TERM_PATTERN, "New Terms")
 
+    @staticmethod
     def _find_latest_file(
-        self, directory: Path, pattern: re.Pattern, report_type: str
+        directory: Path, pattern: re.Pattern, report_type: str
     ) -> Optional[Path]:
         """
         Find the most recent file matching the pattern in the directory.


### PR DESCRIPTION
## Summary
- refactor file finder to use a static method for locating latest payroll reports

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c58cd4e0832888a2f6b93d1ecf72