### PR TITLE
Use model_dump in add_driver

### DIFF
--- a/src/samsara_client.py
+++ b/src/samsara_client.py
@@ -246,7 +246,7 @@ def deactivate_driver_by_external_id(
 
 def add_driver(payload: BaseModel) -> None:
     """Add a new driver to Samsara."""
-    _req("POST", "/fleet/drivers", json=payload.dict(exclude_none=True))
+    _req("POST", "/fleet/drivers", json=payload.model_dump(exclude_none=True))
 
 
 def patch_driver(_id: str, patch: dict) -> None:


### PR DESCRIPTION
## Summary
- use `model_dump` when adding a driver to support Pydantic v2

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893cb58a7cc8328897e8a44d2c961e8