### PR TITLE
refactor: clarify driver status variable

### DIFF
--- a/src/sync_usernames.py
+++ b/src/sync_usernames.py
@@ -62,8 +62,8 @@ def status(
         typer.echo(f"\n⚠️  In Samsara but not in CSV: {len(in_samsara_not_csv)}")
         if verbose and len(in_samsara_not_csv) <= 20:
             for username in sorted(in_samsara_not_csv):
-                status = samsara_status[username]
-                typer.echo(f"   - {username} ({status})")
+                driver_status = samsara_status[username]
+                typer.echo(f"   - {username} ({driver_status})")
         typer.echo("\n💡 Tip: Run 'sync' command to add these to your local CSV")
 
     if not in_csv_not_samsara and not in_samsara_not_csv:


### PR DESCRIPTION
## Summary
- rename temporary `status` variable to `driver_status` in username sync status report

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893cb58f25483288235a09dccca3292