### PR TITLE
refactor username preview to avoid side effects

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -246,8 +246,8 @@ def test():
         from username_manager import get_username_manager
 
         manager = get_username_manager()
-        test_username = manager.make_unique("testuser9999")
-        manager._usernames.discard(test_username)  # Clean up test
+        # Preview a username to ensure manager responds without modifying state
+        _ = manager.check_available("testuser9999")
         typer.echo("   ✅ Username manager working")
         tests_passed += 1
     except Exception as e:

--- a/src/sync_usernames.py
+++ b/src/sync_usernames.py
@@ -168,11 +168,9 @@ def check(
     # Check if it exists
     if manager.exists(base):
         typer.echo(f"Base username '{base}' already exists.")
-        # Find what would be generated
-        test_unique = manager.make_unique(base)
+        # Preview the unique username without modifying state
+        test_unique = manager.check_available(base)
         typer.echo(f"Would generate: {test_unique}")
-        # Remove it since this was just a test
-        manager._usernames.discard(test_unique)
     else:
         typer.echo(f"Username '{base}' is available.")
 


### PR DESCRIPTION
## Summary
- preview username availability using `check_available` in CLI tools
- avoid direct access to private username sets in tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893cb58963c8328928d8d6aae0dd9af