### PR TITLE
refactor: use relative imports within package

### DIFF
--- a/src/add_drivers.py
+++ b/src/add_drivers.py
@@ -3,15 +3,15 @@ import logging
 import json
 from pathlib import Path
 from typing import Optional
-from payroll_reader import read_xlsx
-from transformer import row_to_payload, _generate_paycom_key
-from samsara_client import (
+from .payroll_reader import read_xlsx
+from .transformer import row_to_payload, _generate_paycom_key
+from .samsara_client import (
     add_driver,
     get_driver_by_external_id,
     update_driver_by_external_id,
 )
-from username_manager import get_username_manager
-from file_finder import PayrollFileFinder, get_latest_hire_file
+from .username_manager import get_username_manager
+from .file_finder import PayrollFileFinder, get_latest_hire_file
 
 app = typer.Typer()
 
@@ -107,7 +107,7 @@ def main(
     # Optionally sync existing usernames first
     if sync_first:
         log.info("Syncing existing Samsara usernames (active and deactivated)...")
-        from samsara_client import get_all_drivers
+        from .samsara_client import get_all_drivers
 
         manager = get_username_manager()
         drivers = get_all_drivers(include_deactivated=True)
@@ -392,7 +392,7 @@ def check(
 
         # Check what username would be generated
         import re
-        from username_manager import get_username_manager
+        from .username_manager import get_username_manager
 
         manager = get_username_manager()
         base_username = re.sub(r"[^a-z0-9]", "", f"{first[0]}{last}".lower())

--- a/src/deactivate_drivers.py
+++ b/src/deactivate_drivers.py
@@ -9,8 +9,8 @@ import re
 from pathlib import Path
 from typing import Optional, Dict, List
 import pandas as pd
-from file_finder import PayrollFileFinder, get_latest_term_file
-from samsara_client import (
+from .file_finder import PayrollFileFinder, get_latest_term_file
+from .samsara_client import (
     get_all_drivers,
     patch_driver,
     get_driver_by_external_id,
@@ -334,7 +334,7 @@ def main(
 
                         # Try to add the external ID for future use
                         if paycom_key:
-                            from samsara_client import add_external_id_to_driver
+                            from .samsara_client import add_external_id_to_driver
 
                             add_external_id_to_driver(
                                 driver_id, "paycomname", paycom_key

--- a/src/main.py
+++ b/src/main.py
@@ -7,11 +7,11 @@ import typer
 from datetime import datetime
 
 # Import command modules
-import add_drivers
-import deactivate_drivers
-import sync_usernames
-import migrate_external_ids
-from file_finder import PayrollFileFinder
+from . import add_drivers
+from . import deactivate_drivers
+from . import sync_usernames
+from . import migrate_external_ids
+from .file_finder import PayrollFileFinder
 
 app = typer.Typer(help="Samsara Driver Sync System")
 
@@ -137,7 +137,7 @@ def status():
         typer.echo("  Terms:     No reports found")
 
     # Check username database
-    from username_manager import get_username_manager
+    from .username_manager import get_username_manager
 
     try:
         manager = get_username_manager()
@@ -154,7 +154,7 @@ def status():
     # Check Samsara connection and external IDs
     typer.echo("\n🌐 Samsara API:")
     try:
-        from samsara_client import get_drivers_by_status
+        from .samsara_client import get_drivers_by_status
 
         active = get_drivers_by_status("active")
         deactivated = get_drivers_by_status("deactivated")
@@ -229,7 +229,10 @@ def test():
     # Test 3: Mapping files
     typer.echo("\n3. Testing mapping files...")
     try:
-        from mapping_loader import load_position_tags, load_location_tags_and_timezones
+        from .mapping_loader import (
+            load_position_tags,
+            load_location_tags_and_timezones,
+        )
 
         positions = load_position_tags()
         locations = load_location_tags_and_timezones()
@@ -243,7 +246,7 @@ def test():
     # Test 4: Username manager
     typer.echo("\n4. Testing username manager...")
     try:
-        from username_manager import get_username_manager
+        from .username_manager import get_username_manager
 
         manager = get_username_manager()
         # Preview a username to ensure manager responds without modifying state
@@ -257,7 +260,7 @@ def test():
     # Test 5: Samsara API
     typer.echo("\n5. Testing Samsara API connection...")
     try:
-        from samsara_client import get_drivers_by_status
+        from .samsara_client import get_drivers_by_status
 
         drivers = get_drivers_by_status("active")
         typer.echo(f"   ✅ API connected ({len(drivers)} active drivers)")
@@ -269,7 +272,7 @@ def test():
     # Test 6: External ID support
     typer.echo("\n6. Testing external ID functions...")
     try:
-        from samsara_client import get_driver_by_external_id
+        from .samsara_client import get_driver_by_external_id
 
         # Test with a non-existent ID (should return None, not error)
         result = get_driver_by_external_id("paycomname", "test_nonexistent_2099-01-01")
@@ -313,7 +316,7 @@ def quickstart():
     typer.echo("\nStep 2: Sync existing Samsara usernames...")
     typer.echo("This ensures we don't create duplicate usernames.")
     if typer.confirm("Sync usernames from Samsara?", default=True):
-        from sync_usernames import sync
+        from .sync_usernames import sync
 
         sync(verbose=False)
 
@@ -321,7 +324,7 @@ def quickstart():
     typer.echo("\nStep 3: Check external ID coverage...")
     typer.echo("External IDs ensure reliable driver matching.")
     if typer.confirm("Check external ID status?", default=True):
-        from migrate_external_ids import verify
+        from .migrate_external_ids import verify
 
         verify(verbose=False)
 

--- a/src/migrate_external_ids.py
+++ b/src/migrate_external_ids.py
@@ -38,7 +38,7 @@ def backfill_external_ids(
     2. A CSV file with name and hire_date columns (--csv, dates in MM-DD-YYYY format)
     3. Manual entry for individual drivers
     """
-    from samsara_client import get_all_drivers, add_external_id_to_driver
+    from .samsara_client import get_all_drivers, add_external_id_to_driver
 
     # Setup logging
     level = logging.DEBUG if verbose else logging.INFO
@@ -80,7 +80,7 @@ def backfill_external_ids(
         # Load from hire report Excel
         typer.echo(f"\n📄 Loading employee data from: {hire_report}")
         try:
-            from payroll_reader import read_xlsx
+            from .payroll_reader import read_xlsx
 
             df = read_xlsx(hire_report)
             for _, row in df.iterrows():
@@ -215,7 +215,7 @@ def verify(
     """
     Verify the external ID coverage for all drivers.
     """
-    from samsara_client import get_all_drivers
+    from .samsara_client import get_all_drivers
 
     typer.echo("\n🔍 Verifying External ID Coverage...")
 
@@ -277,7 +277,7 @@ def add_single(
     """
     Add external ID for a single driver.
     """
-    from samsara_client import get_all_drivers, add_external_id_to_driver
+    from .samsara_client import get_all_drivers, add_external_id_to_driver
     import pandas as pd
 
     # Parse hire date

--- a/src/sync_usernames.py
+++ b/src/sync_usernames.py
@@ -6,8 +6,8 @@ Run this initially to populate usernames.csv with all existing drivers.
 import typer
 import logging
 from pathlib import Path
-from samsara_client import get_all_drivers, get_driver_usernames
-from username_manager import get_username_manager
+from .samsara_client import get_all_drivers, get_driver_usernames
+from .username_manager import get_username_manager
 
 app = typer.Typer()
 

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -1,20 +1,23 @@
-from src.models import DriverAddPayload
+from .models import DriverAddPayload
 from config import settings
-from username_manager import get_username_manager
 import re
 import logging
 import pandas as pd
-from mapping_loader import (
-    load_position_tags,
-    load_location_tags_and_timezones,
-    load_never_positions,
+import importlib
+import sys
+
+mapping_loader = sys.modules.get("mapping_loader") or importlib.import_module(
+    ".mapping_loader", __package__
+)
+username_manager = sys.modules.get("username_manager") or importlib.import_module(
+    ".username_manager", __package__
 )
 
 # cache mappings
-_POS_TAGS = load_position_tags()
-_LOC_MAP = load_location_tags_and_timezones()
-_EXCLUDE_POS = load_never_positions()
-_USERNAME_MGR = get_username_manager()
+_POS_TAGS = mapping_loader.load_position_tags()
+_LOC_MAP = mapping_loader.load_location_tags_and_timezones()
+_EXCLUDE_POS = mapping_loader.load_never_positions()
+_USERNAME_MGR = username_manager.get_username_manager()
 _log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- use explicit relative imports for all intra-package modules
- keep lazy imports consistent with dotted syntax

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689515d2ee20832892ead18c3e93e0b7