### PR TITLE
refactor: add main entrypoints to CLIs

### DIFF
--- a/external-id-implementation-guide.md
+++ b/external-id-implementation-guide.md
@@ -53,17 +53,17 @@ Migration utilities for existing drivers:
 ### Initial Setup (One-Time)
 ```bash
 # 1. Check system status
-python main.py status
+python -m src.main status
 
 # 2. Sync existing usernames
-python main.py username sync
+python -m src.main username sync
 
 # 3. Check external ID coverage
-python main.py migrate verify
+python -m src.main migrate verify
 
 # 4. Migrate existing drivers (if needed)
-python main.py migrate backfill-external-ids --hire-report path/to/recent_report.xlsx --dry-run
-python main.py migrate backfill-external-ids --hire-report path/to/recent_report.xlsx --execute
+python -m src.main migrate backfill-external-ids --hire-report path/to/recent_report.xlsx --dry-run
+python -m src.main migrate backfill-external-ids --hire-report path/to/recent_report.xlsx --execute
 ```
 
 ### Daily Operations
@@ -71,35 +71,35 @@ python main.py migrate backfill-external-ids --hire-report path/to/recent_report
 #### Process Everything (Recommended)
 ```bash
 # Preview changes
-python main.py process --dry-run
+python -m src.main process --dry-run
 
 # Execute with updates/reactivations
-python main.py process --update
+python -m src.main process --update
 
 # Execute without updates
-python main.py process
+python -m src.main process
 ```
 
 #### Process Individual Reports
 ```bash
 # Add new hires only
-python main.py add --update
+python -m src.main add --update
 
 # Deactivate terminations only
-python main.py deactivate
+python -m src.main deactivate
 
 # List available files
-python main.py add --list
-python main.py deactivate --list
+python -m src.main add --list
+python -m src.main deactivate --list
 ```
 
 #### Check Individual Drivers
 ```bash
 # Check if a driver exists
-python main.py add check John Smith 01-15-2024
+python -m src.main add check John Smith 01-15-2024
 
 # Check termination lookup
-python main.py deactivate check John Smith --hire-date 01-15-2024
+python -m src.main deactivate check John Smith --hire-date 01-15-2024
 ```
 
 ### Migration Commands
@@ -107,24 +107,24 @@ python main.py deactivate check John Smith --hire-date 01-15-2024
 #### Bulk Migration
 ```bash
 # Using a hire report
-python main.py migrate backfill-external-ids --hire-report report.xlsx --execute
+python -m src.main migrate backfill-external-ids --hire-report report.xlsx --execute
 
 # Using a custom CSV (columns: name, hire_date)
-python main.py migrate backfill-external-ids --csv employees.csv --execute
+python -m src.main migrate backfill-external-ids --csv employees.csv --execute
 ```
 
 #### Individual Migration
 ```bash
-python main.py migrate add-single John Smith 01-15-2024 --execute
+python -m src.main migrate add-single John Smith 01-15-2024 --execute
 ```
 
 #### Verification
 ```bash
 # Basic coverage stats
-python main.py migrate verify
+python -m src.main migrate verify
 
 # Detailed information
-python main.py migrate verify --verbose
+python -m src.main migrate verify --verbose
 ```
 
 ## Benefits
@@ -163,30 +163,30 @@ When an employee is rehired:
 ### Driver Not Found During Termination
 ```bash
 # Check if driver exists
-python main.py deactivate check FirstName LastName --hire-date MM-DD-YYYY
+python -m src.main deactivate check FirstName LastName --hire-date MM-DD-YYYY
 
 # If not found, verify the hire date matches exactly
-# Or enable fallback: python main.py deactivate --fallback
+# Or enable fallback: python -m src.main deactivate --fallback
 ```
 
 ### Duplicate Driver Created
 ```bash
 # Check external ID coverage
-python main.py migrate verify --verbose
+python -m src.main migrate verify --verbose
 
 # Find and fix duplicates manually, then add external ID
-python main.py migrate add-single FirstName LastName MM-DD-YYYY --execute
+python -m src.main migrate add-single FirstName LastName MM-DD-YYYY --execute
 ```
 
 ### Migration Issues
 ```bash
 # Extract hire dates from driver notes (if stored there)
-python main.py migrate backfill-external-ids --dry-run
+python -m src.main migrate backfill-external-ids --dry-run
 
 # Create manual CSV for missing data
 echo "name,hire_date" > manual_fixes.csv
 echo "John Smith,01-15-2024" >> manual_fixes.csv
-python main.py migrate backfill-external-ids --csv manual_fixes.csv --execute
+python -m src.main migrate backfill-external-ids --csv manual_fixes.csv --execute
 ```
 
 ## Best Practices

--- a/src/add_drivers.py
+++ b/src/add_drivers.py
@@ -16,8 +16,7 @@ from .file_finder import PayrollFileFinder, get_latest_hire_file
 app = typer.Typer()
 
 
-@app.command()
-def main(
+def add(
     file: Optional[str] = typer.Argument(
         None, help="Path to Excel file. If not provided, uses latest from OneDrive"
     ),
@@ -341,6 +340,39 @@ def main(
         raise typer.Exit(1)
 
 
+@app.callback(invoke_without_command=True)
+def _main(
+    ctx: typer.Context,
+    file: Optional[str] = typer.Argument(
+        None, help="Path to Excel file. If not provided, uses latest from OneDrive"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview changes without making API calls"
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose logging"
+    ),
+    sync_first: bool = typer.Option(
+        False, "--sync", help="Sync with Samsara before processing"
+    ),
+    list_files: bool = typer.Option(
+        False, "--list", help="List available report files and exit"
+    ),
+    update_existing: bool = typer.Option(
+        False, "--update", help="Update existing drivers if found"
+    ),
+) -> None:
+    if ctx.invoked_subcommand is None:
+        add(
+            file=file,
+            dry_run=dry_run,
+            verbose=verbose,
+            sync_first=sync_first,
+            list_files=list_files,
+            update_existing=update_existing,
+        )
+
+
 @app.command()
 def check(
     first: str = typer.Argument(..., help="First name"),
@@ -402,5 +434,9 @@ def check(
             typer.echo("   A modified username would be generated")
 
 
-if __name__ == "__main__":
+def main() -> None:
     app()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deactivate_drivers.py
+++ b/src/deactivate_drivers.py
@@ -124,8 +124,7 @@ def find_driver_by_name(
     return None
 
 
-@app.command()
-def main(
+def deactivate(
     file: Optional[str] = typer.Argument(
         None,
         help="Path to termination Excel file. If not provided, uses latest from OneDrive",
@@ -397,6 +396,38 @@ def main(
         raise typer.Exit(1)
 
 
+@app.callback(invoke_without_command=True)
+def _main(
+    ctx: typer.Context,
+    file: Optional[str] = typer.Argument(
+        None,
+        help="Path to termination Excel file. If not provided, uses latest from OneDrive",
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview changes without making API calls"
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose logging"
+    ),
+    list_files: bool = typer.Option(
+        False, "--list", help="List available termination files and exit"
+    ),
+    fallback: bool = typer.Option(
+        True,
+        "--fallback/--no-fallback",
+        help="Use name matching as fallback when external ID not found",
+    ),
+) -> None:
+    if ctx.invoked_subcommand is None:
+        deactivate(
+            file=file,
+            dry_run=dry_run,
+            verbose=verbose,
+            list_files=list_files,
+            fallback=fallback,
+        )
+
+
 @app.command()
 def check(
     first: str = typer.Argument(..., help="First name"),
@@ -459,5 +490,9 @@ def check(
             typer.echo(f"   Searched for external ID: paycomname:{paycom_key}")
 
 
-if __name__ == "__main__":
+def main() -> None:
     app()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -55,7 +55,7 @@ def process(
     typer.echo("📋 Step 1: Processing Terminations")
     typer.echo("-" * 40)
     try:
-        deactivate_drivers.main(
+        deactivate_drivers.deactivate(
             file=None,  # Use latest
             dry_run=dry_run,
             verbose=verbose,
@@ -72,7 +72,7 @@ def process(
     typer.echo("📋 Step 2: Processing New Hires")
     typer.echo("-" * 40)
     try:
-        add_drivers.main(
+        add_drivers.add(
             file=None,  # Use latest
             dry_run=dry_run,
             verbose=verbose,
@@ -336,27 +336,33 @@ def quickstart():
             typer.echo("\nMigration options:")
             typer.echo("1. If you have a recent hire report with all employees:")
             typer.echo(
-                "   python main.py migrate backfill-external-ids --hire-report path/to/report.xlsx --execute"
+                "   python -m src.main migrate backfill-external-ids --hire-report path/to/report.xlsx --execute"
             )
             typer.echo("\n2. For individual drivers:")
             typer.echo(
-                "   python main.py migrate add-single John Smith 01-15-2024 --execute"
+                "   python -m src.main migrate add-single John Smith 01-15-2024 --execute"
             )
 
     # Step 4: Process reports
     typer.echo("\nStep 4: Process payroll reports...")
     typer.echo("You can now process new hires and terminations.")
     typer.echo("\nCommon commands:")
-    typer.echo("  • Dry run (preview): python main.py process --dry-run")
-    typer.echo("  • Process all:       python main.py process")
-    typer.echo("  • With updates:      python main.py process --update")
-    typer.echo("  • Just new hires:    python main.py add")
-    typer.echo("  • Just terminations: python main.py deactivate")
+    typer.echo("  • Dry run (preview): python -m src.main process --dry-run")
+    typer.echo("  • Process all:       python -m src.main process")
+    typer.echo("  • With updates:      python -m src.main process --update")
+    typer.echo("  • Just new hires:    python -m src.main add")
+    typer.echo("  • Just terminations: python -m src.main deactivate")
 
     typer.echo("\n✅ Setup complete! You're ready to sync drivers.")
-    typer.echo("\n📚 For more help, check the README or run: python main.py --help")
-    typer.echo("=" * 60 + "\n")
+
+
+typer.echo("\n📚 For more help, check the README or run: python -m src.main --help")
+typer.echo("=" * 60 + "\n")
+
+
+def main() -> None:
+    app()
 
 
 if __name__ == "__main__":
-    app()
+    main()

--- a/src/migrate_external_ids.py
+++ b/src/migrate_external_ids.py
@@ -199,7 +199,7 @@ def backfill_external_ids(
         typer.echo("   1. Create a CSV with columns: name, hire_date")
         typer.echo("   2. Format dates as MM-DD-YYYY")
         typer.echo(
-            "   3. Run: python migrate_external_ids.py backfill-external-ids --csv your_file.csv"
+            "   3. Run: python -m src.migrate_external_ids backfill-external-ids --csv your_file.csv"
         )
 
     if dry_run:

--- a/usage_guide.md
+++ b/usage_guide.md
@@ -18,40 +18,40 @@ The utilities will raise an `EnvironmentError` if it is missing.
 ### 1. Process Everything (Recommended)
 ```bash
 # Process both terminations and new hires using latest files
-python main.py process
+python -m src.main process
 
 # Test mode - preview changes without applying
-python main.py process --dry-run
+python -m src.main process --dry-run
 ```
 
 ### 2. Process New Hires Only
 ```bash
 # Use the latest New Hires Report automatically
-python add_drivers.py
+python -m src.add_drivers
 
 # Or specify a file manually
-python add_drivers.py "C:\path\to\specific_file.xlsx"
+python -m src.add_drivers "C:\path\to\specific_file.xlsx"
 
 # List available hire reports
-python add_drivers.py --list
+python -m src.add_drivers --list
 
 # Dry run to preview
-python add_drivers.py --dry-run
+python -m src.add_drivers --dry-run
 ```
 
 ### 3. Process Terminations Only
 ```bash
 # Use the latest New Terms Report automatically
-python deactivate_drivers.py
+python -m src.deactivate_drivers
 
 # Or specify a file manually
-python deactivate_drivers.py "C:\path\to\specific_file.xlsx"
+python -m src.deactivate_drivers "C:\path\to\specific_file.xlsx"
 
 # List available termination reports
-python deactivate_drivers.py --list
+python -m src.deactivate_drivers --list
 
 # Check if a specific person exists
-python deactivate_drivers.py check John Smith
+python -m src.deactivate_drivers check John Smith
 ```
 
 ## Main Commands
@@ -60,25 +60,25 @@ python deactivate_drivers.py check John Smith
 
 ```bash
 # Full processing workflow
-python main.py process
+python -m src.main process
 
 # Check system status
-python main.py status
+python -m src.main status
 
 # Run system tests
-python main.py test
+python -m src.main test
 
 # Username management
-python main.py username sync           # Sync with Samsara
-python main.py username stats          # Show statistics
-python main.py username check John Smith  # Test username generation
+python -m src.main username sync           # Sync with Samsara
+python -m src.main username stats          # Show statistics
+python -m src.main username check John Smith  # Test username generation
 ```
 
 ### Individual Scripts
 
 #### Add Drivers
 ```bash
-python add_drivers.py [OPTIONS] [FILE]
+python -m src.add_drivers [OPTIONS] [FILE]
 
 Options:
   --dry-run        Preview without making changes
@@ -89,7 +89,7 @@ Options:
 
 #### Deactivate Drivers
 ```bash
-python deactivate_drivers.py [OPTIONS] [FILE]
+python -m src.deactivate_drivers [OPTIONS] [FILE]
 
 Options:
   --dry-run        Preview without making changes
@@ -100,16 +100,16 @@ Options:
 #### Username Management
 ```bash
 # Sync existing Samsara usernames to local CSV
-python sync_usernames.py sync
+python -m src.sync_usernames sync
 
 # Check what username would be generated
-python sync_usernames.py check John Smith
+python -m src.sync_usernames check John Smith
 
 # Show username statistics
-python sync_usernames.py stats
+python -m src.sync_usernames stats
 
 # Check sync status with Samsara
-python sync_usernames.py status
+python -m src.sync_usernames status
 ```
 
 ## File Detection
@@ -161,7 +161,7 @@ LOG_FILE=driver_sync.log
 ### Daily Processing
 ```bash
 # Run the complete workflow
-python main.py process
+python -m src.main process
 
 # Output:
 # ============================================================
@@ -187,27 +187,27 @@ python main.py process
 ### Testing Changes
 ```bash
 # Always test first!
-python main.py process --dry-run --verbose
+python -m src.main process --dry-run --verbose
 
 # Check individual operations
-python add_drivers.py --dry-run
-python deactivate_drivers.py --dry-run
+python -m src.add_drivers --dry-run
+python -m src.deactivate_drivers --dry-run
 ```
 
 ### Troubleshooting
 ```bash
 # Check system status
-python main.py status
+python -m src.main status
 
 # Run system tests
-python main.py test
+python -m src.main test
 
 # Check username conflicts
-python sync_usernames.py status --verbose
+python -m src.sync_usernames status --verbose
 
 # List available files
-python add_drivers.py --list
-python deactivate_drivers.py --list
+python -m src.add_drivers --list
+python -m src.deactivate_drivers --list
 ```
 
 ## Username Handling
@@ -239,8 +239,8 @@ The system handles common issues:
 ## Best Practices
 
 1. **Always run with `--dry-run` first** to preview changes
-2. **Use `main.py process`** for the complete workflow
-3. **Check `main.py status`** before processing to verify setup
+2. **Use `python -m src.main process`** for the complete workflow
+3. **Check `python -m src.main status`** before processing to verify setup
 4. **Keep mapping CSV files updated** as locations/positions change
 5. **Run `username sync`** periodically to stay synchronized
 6. **Process terminations before new hires** to free up usernames
@@ -253,7 +253,7 @@ To run automatically, create a Windows Task Scheduler task:
 ```batch
 @echo off
 cd C:\path\to\your\project
-python main.py process >> sync_log.txt 2>&1
+python -m src.main process >> sync_log.txt 2>&1
 ```
 
 Schedule this to run daily after your OneDrive sync completes.


### PR DESCRIPTION
## Summary
- add reusable `main()` wrappers for CLI modules
- update Typer command registration with default callbacks
- document module entry points via `python -m src.*`

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68951a07dda083288a438627812f67c2