### PR TITLE
chore: enable ruff autofix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     rev: v0.12.7
     hooks:
       - id: ruff
-        args: ["--select=E9,F63,F7,F82"]
+        args: ["--fix"]
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:

--- a/tests/test_username_manager.py
+++ b/tests/test_username_manager.py
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from src.username_manager import UsernameManager
+from src.username_manager import UsernameManager  # noqa: E402
 
 
 def test_batching(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- enable ruff autofix in pre-commit config
- quiet ruff import-order warning in username_manager test

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68952119a024832885e79cebb0127d3b