### PR TITLE
Add README with installation and CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Samsara Fleet Lite
+
+A minimal SDK and CLI for syncing drivers with the Samsara Fleet Management API.
+For full workflow details and advanced options, see the [Usage Guide](usage_guide.md).
+
+## Installation
+
+Install in editable mode with development dependencies:
+
+```bash
+pip install -e .[dev]
+```
+
+## Command Line Usage
+
+Use the provided console scripts to preview changes with your report files:
+
+```bash
+add-drivers path/to/New_Hires.xlsx --dry-run
+deactivate-drivers path/to/Terms.xlsx --dry-run
+```
+
+### Alternative invocation
+
+If the console scripts are unavailable, call the modules directly:
+
+```bash
+PYTHONPATH=$PWD/src python -m src.add_drivers path/to/New_Hires.xlsx --dry-run
+```
+
+## Next steps
+
+Read the [Usage Guide](usage_guide.md) for environment variables, batch processing,
+and additional commands.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import os
 import sys
 from pathlib import Path
@@ -83,7 +84,9 @@ def test_add_dry_run_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     assert result.exit_code == 0
 
 
-def test_add_dry_run_update_verbose(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_add_dry_run_update_verbose(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     dummy = tmp_path / "dummy.xlsx"
     dummy.touch()
     df = _dummy_add_df()
@@ -94,13 +97,17 @@ def test_add_dry_run_update_verbose(tmp_path: Path, monkeypatch: pytest.MonkeyPa
         lambda *a, **k: {"driverActivationStatus": "active"},
     )
     monkeypatch.setattr(add_module, "add_driver", lambda *a, **k: True)
-    monkeypatch.setattr(add_module, "update_driver_by_external_id", lambda *a, **k: True)
+    monkeypatch.setattr(
+        add_module, "update_driver_by_external_id", lambda *a, **k: True
+    )
     monkeypatch.setattr(add_module, "row_to_payload", lambda row: DummyPayload())
     result = runner.invoke(add_main, ["--dry-run", "--update", "-v", str(dummy)])
     assert result.exit_code == 0
 
 
-def test_deactivate_dry_run_no_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_deactivate_dry_run_no_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     dummy = tmp_path / "dummy.xlsx"
     dummy.touch()
     df = _dummy_term_df()
@@ -114,16 +121,22 @@ def test_deactivate_dry_run_no_fallback(tmp_path: Path, monkeypatch: pytest.Monk
     assert result.exit_code == 0
 
 
-def test_deactivate_dry_run_fallback_verbose(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_deactivate_dry_run_fallback_verbose(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     dummy = tmp_path / "dummy.xlsx"
     dummy.touch()
     df = _dummy_term_df()
     monkeypatch.setattr(deactivate_module, "read_terminations_xlsx", lambda path: df)
-    monkeypatch.setattr(deactivate_module, "get_driver_by_external_id", lambda *a, **k: None)
+    monkeypatch.setattr(
+        deactivate_module, "get_driver_by_external_id", lambda *a, **k: None
+    )
     monkeypatch.setattr(
         deactivate_module,
         "get_all_drivers",
-        lambda include_deactivated=False: [{"id": "1", "name": "A B", "driverActivationStatus": "active"}],
+        lambda include_deactivated=False: [
+            {"id": "1", "name": "A B", "driverActivationStatus": "active"}
+        ],
     )
     monkeypatch.setattr(
         deactivate_module,
@@ -145,7 +158,9 @@ def test_update_dry_run_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
         "get_driver_by_external_id",
         lambda *a, **k: {"id": "1"},
     )
-    monkeypatch.setattr(update_module, "update_driver_by_external_id", lambda *a, **k: True)
+    monkeypatch.setattr(
+        update_module, "update_driver_by_external_id", lambda *a, **k: True
+    )
     monkeypatch.setattr(update_module, "row_to_payload", lambda row: DummyPayload())
     result = runner.invoke(update_main, ["--dry-run", str(dummy)])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- Add project README highlighting editable install, console scripts, and usage guide
- Ignore E402 import-order lint in CLI tests for pre-commit compliance

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689526b25058832887cbce9ff0f8fb59