### PR TITLE
Normalize external ID keys before API requests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from src.file_finder import PayrollFileFinder
+from src.file_finder import PayrollFileFinder  # noqa: E402
 
 
 @pytest.fixture
@@ -41,4 +41,3 @@ def payroll_finder(sample_report_dirs: Tuple[Path, Path]) -> PayrollFileFinder:
     """Return a PayrollFileFinder configured with the sample directories."""
     hires_dir, terms_dir = sample_report_dirs
     return PayrollFileFinder(hires_dir=hires_dir, terms_dir=terms_dir)
-

--- a/tests/test_external_ids.py
+++ b/tests/test_external_ids.py
@@ -1,0 +1,48 @@
+import importlib
+
+
+def test_normalize_external_ids(monkeypatch):
+    monkeypatch.setenv("SAMSARA_BEARER_TOKEN", "token")
+    import src.samsara_client as sc
+
+    importlib.reload(sc)
+
+    payload = {
+        "externalIds": {
+            "EncompassId": "8199",
+            "encompass_id": "8199",
+            "OTHER": "1",
+        }
+    }
+    sc._normalize_external_ids(payload)
+    assert payload["externalIds"] == {"encompassId": "8199", "OTHER": "1"}
+
+
+def test_req_normalizes_external_ids(monkeypatch):
+    monkeypatch.setenv("SAMSARA_BEARER_TOKEN", "token")
+    import src.samsara_client as sc
+
+    importlib.reload(sc)
+
+    class DummyResp:
+        status_code = 200
+
+        def json(self):
+            return {}
+
+    captured = {}
+
+    def fake_request(method, url, timeout=10, **kw):
+        captured["json"] = kw.get("json")
+        return DummyResp()
+
+    monkeypatch.setattr(sc.SESSION, "request", fake_request)
+
+    sc._req(
+        "PATCH",
+        "/fleet/drivers/1",
+        json={"externalIds": {"EncompassId": "8199", "encompass_id": "8199"}},
+    )
+
+    assert captured["json"]["externalIds"] == {"encompassId": "8199"}
+

--- a/tests/test_file_finder.py
+++ b/tests/test_file_finder.py
@@ -2,13 +2,12 @@ import sys
 from pathlib import Path
 from typing import Tuple
 
-import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from src.file_finder import PayrollFileFinder
+from src.file_finder import PayrollFileFinder  # noqa: E402
 
 
 def test_find_latest_reports(
@@ -68,4 +67,3 @@ def test_list_all_reports(payroll_finder: PayrollFileFinder) -> None:
         for item in reports[key]:
             assert {"path", "name", "size", "exists"}.issubset(item)
             assert "timestamp" in item
-

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -12,9 +12,9 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-import src.main as main_module
-import src.username_manager as username_manager_module
-import src.samsara_client as samsara_client_module
+import src.main as main_module  # noqa: E402
+import src.username_manager as username_manager_module  # noqa: E402
+import src.samsara_client as samsara_client_module  # noqa: E402
 
 runner = CliRunner()
 
@@ -52,7 +52,9 @@ def test_process_handles_missing_reports(monkeypatch: pytest.MonkeyPatch) -> Non
         calls.append("add")
         raise FileNotFoundError
 
-    monkeypatch.setattr(main_module.deactivate_drivers, "deactivate", missing_deactivate)
+    monkeypatch.setattr(
+        main_module.deactivate_drivers, "deactivate", missing_deactivate
+    )
     monkeypatch.setattr(main_module.add_drivers, "add", missing_add)
 
     result = runner.invoke(main_module.app, ["process"])
@@ -62,7 +64,9 @@ def test_process_handles_missing_reports(monkeypatch: pytest.MonkeyPatch) -> Non
     assert "No hire reports found" in result.output
 
 
-def test_status_reports_and_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_status_reports_and_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     hires_dir = tmp_path / "hires"
     terms_dir = tmp_path / "terms"
     hires_dir.mkdir()

--- a/tests/test_mapping_loader.py
+++ b/tests/test_mapping_loader.py
@@ -29,7 +29,9 @@ def test_load_position_tags(mapping_dir: Path, monkeypatch: pytest.MonkeyPatch) 
     assert ml.load_position_tags() == {"Driver": "123"}
 
 
-def test_load_location_tags_and_timezones(mapping_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_location_tags_and_timezones(
+    mapping_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(ml, "BASE_DIR", mapping_dir)
     assert ml.load_location_tags_and_timezones() == {
         "HQ": {"tag_id": "999", "timezone": "America/Chicago"},
@@ -37,6 +39,8 @@ def test_load_location_tags_and_timezones(mapping_dir: Path, monkeypatch: pytest
     }
 
 
-def test_load_never_positions(mapping_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_never_positions(
+    mapping_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(ml, "BASE_DIR", mapping_dir)
     assert ml.load_never_positions() == {"Intern"}

--- a/tests/test_migrate_external_ids.py
+++ b/tests/test_migrate_external_ids.py
@@ -13,7 +13,6 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-import src.migrate_external_ids as migrate_module
 from src.migrate_external_ids import app as migrate_main
 import src.samsara_client as sc
 import logging

--- a/tests/test_payroll_reader.py
+++ b/tests/test_payroll_reader.py
@@ -3,7 +3,6 @@ import sys
 from pathlib import Path
 
 import pandas as pd
-import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -35,4 +34,3 @@ def test_read_xlsx_filters_and_formats(tmp_path: Path) -> None:
     assert (result.Employee_Status == "Active").all()
     assert pd.api.types.is_datetime64_any_dtype(result.Hire_Date)
     assert len(result) == 2
-

--- a/tests/test_sync_usernames_cli.py
+++ b/tests/test_sync_usernames_cli.py
@@ -47,9 +47,7 @@ class DummyManager:
 
 def test_status_mismatched(monkeypatch: pytest.MonkeyPatch) -> None:
     manager = DummyManager({"alice", "bob"})
-    monkeypatch.setattr(
-        sync_module, "get_username_manager", lambda path=None: manager
-    )
+    monkeypatch.setattr(sync_module, "get_username_manager", lambda path=None: manager)
     monkeypatch.setattr(
         sync_module,
         "get_driver_usernames",
@@ -63,11 +61,11 @@ def test_status_mismatched(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_status_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     manager = DummyManager(set())
-    monkeypatch.setattr(
-        sync_module, "get_username_manager", lambda path=None: manager
-    )
+    monkeypatch.setattr(sync_module, "get_username_manager", lambda path=None: manager)
+
     def _boom(*_args, **_kwargs):  # noqa: ANN001
         raise RuntimeError("boom")
+
     monkeypatch.setattr(sync_module, "get_driver_usernames", _boom)
     result = runner.invoke(username_app, ["status"])
     assert result.exit_code != 0
@@ -76,9 +74,7 @@ def test_status_failure(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_sync_success(monkeypatch: pytest.MonkeyPatch) -> None:
     manager = DummyManager({"alice"})
-    monkeypatch.setattr(
-        sync_module, "get_username_manager", lambda path=None: manager
-    )
+    monkeypatch.setattr(sync_module, "get_username_manager", lambda path=None: manager)
     monkeypatch.setattr(
         sync_module,
         "get_all_drivers",
@@ -95,11 +91,11 @@ def test_sync_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_sync_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     manager = DummyManager(set())
-    monkeypatch.setattr(
-        sync_module, "get_username_manager", lambda path=None: manager
-    )
+    monkeypatch.setattr(sync_module, "get_username_manager", lambda path=None: manager)
+
     def _fail(*_args, **_kwargs):  # noqa: ANN001
         raise RuntimeError("api down")
+
     monkeypatch.setattr(sync_module, "get_all_drivers", _fail)
     result = runner.invoke(username_app, ["sync"])
     assert result.exit_code != 0
@@ -108,9 +104,7 @@ def test_sync_failure(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_check_existing_username(monkeypatch: pytest.MonkeyPatch) -> None:
     manager = DummyManager({"jdoe"})
-    monkeypatch.setattr(
-        sync_module, "get_username_manager", lambda path=None: manager
-    )
+    monkeypatch.setattr(sync_module, "get_username_manager", lambda path=None: manager)
     result = runner.invoke(username_app, ["check", "John", "Doe"])
     assert result.exit_code == 0
     assert "Base username 'jdoe' already exists." in result.output
@@ -119,9 +113,7 @@ def test_check_existing_username(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_stats_duplicates(monkeypatch: pytest.MonkeyPatch) -> None:
     manager = DummyManager({"alice", "bob1", "bob2"})
-    monkeypatch.setattr(
-        sync_module, "get_username_manager", lambda path=None: manager
-    )
+    monkeypatch.setattr(sync_module, "get_username_manager", lambda path=None: manager)
     result = runner.invoke(username_app, ["stats"])
     assert result.exit_code == 0
     assert "Total usernames: 3" in result.output


### PR DESCRIPTION
## Summary
- collapse case and underscore variations of Encompass ID into a single `encompassId` key before calling the Samsara API
- test normalization helper and verify `_req` applies it
- tidy test imports for lint compliance

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade795d93c8328a48f4957ea0d4c3d