### PR TITLE
Normalize Encompass external ID variants

### DIFF
--- a/src/samsara_client.py
+++ b/src/samsara_client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import backoff
 import logging
 import os
+import re
 import requests
 from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel
@@ -29,8 +30,9 @@ def _normalize_external_ids(payload: dict[str, Any]) -> None:
     """Canonicalize external ID keys to avoid duplicates.
 
     Collapses variants of the Encompass ID so that only one key is sent to the
-    API. Keys differing only by case or underscores (e.g. ``EncompassId`` vs
-    ``encompass_id``) are normalized to ``encompassId``.
+    API. Keys differing only by case, underscores, or hyphens (e.g.
+    ``EncompassId`` vs ``encompass_id`` or ``encompass-id``) are normalized to
+    ``encompassId``.
     """
     ids = payload.get("externalIds")
     if not isinstance(ids, dict):
@@ -38,7 +40,7 @@ def _normalize_external_ids(payload: dict[str, Any]) -> None:
 
     canonical: dict[str, str] = {}
     for key, value in ids.items():
-        normalized_key = key.replace("_", "").lower()
+        normalized_key = re.sub(r"[^a-z0-9]", "", key.lower())
         canon = "encompassId" if normalized_key == "encompassid" else key
         if canon not in canonical:
             canonical[canon] = value

--- a/tests/test_external_ids.py
+++ b/tests/test_external_ids.py
@@ -11,6 +11,7 @@ def test_normalize_external_ids(monkeypatch):
         "externalIds": {
             "EncompassId": "8199",
             "encompass_id": "8199",
+            "encompass-id": "8199",
             "OTHER": "1",
         }
     }
@@ -41,8 +42,13 @@ def test_req_normalizes_external_ids(monkeypatch):
     sc._req(
         "PATCH",
         "/fleet/drivers/1",
-        json={"externalIds": {"EncompassId": "8199", "encompass_id": "8199"}},
+        json={
+            "externalIds": {
+                "EncompassId": "8199",
+                "encompass_id": "8199",
+                "encompass-id": "8199",
+            }
+        },
     )
 
     assert captured["json"]["externalIds"] == {"encompassId": "8199"}
-


### PR DESCRIPTION
## Summary
- broaden Encompass external ID normalization to strip hyphens and other separators
- extend tests to cover new Encompass external ID variants

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adf613ca788328add8ca5900169aeb